### PR TITLE
TextObjects do not appear/show up in Dashboards without aligning them

### DIFF
--- a/src/main/java/nl/han/ica/oopg/objects/TextObject.java
+++ b/src/main/java/nl/han/ica/oopg/objects/TextObject.java
@@ -38,6 +38,7 @@ public class TextObject extends GameObject {
     public void draw(PGraphics g) {
 
         g.fill(this.r, this.g, this.b, this.alpha);
+	g.textAlign(g.LEFT, g.TOP);
         g.textSize(fontSize);
         g.text(text, x, y);
     }


### PR DESCRIPTION
Added 		

g.textAlign(g.LEFT, g.TOP)

in the draw method to give the TextObject a default alignment so it gets painted in a Dashboard. It removes the use of a game specific TextObject like in the Waterworld-example.
